### PR TITLE
Added ability for customizing bounty's blocks per village type

### DIFF
--- a/src/main/kotlin/ejektaflex/bountiful/SetupLifecycle.kt
+++ b/src/main/kotlin/ejektaflex/bountiful/SetupLifecycle.kt
@@ -54,6 +54,7 @@ object SetupLifecycle {
                         event.server,
                         ResourceLocation("bountiful:village/common/bounty_gazebo"),
                         ResourceLocation("minecraft:village/$villageType/houses"),
+                        ResourceLocation("bountiful:$villageType"),
                         BountifulConfig.SERVER.villageGenRate.get()
                     )
                 }
@@ -66,6 +67,7 @@ object SetupLifecycle {
                             event.server,
                             ResourceLocation("bountiful:village/common/bounty_gazebo"),
                             ResourceLocation("repurposed_structures:village/$villageType/houses"),
+                            ResourceLocation("bountiful:$villageType"),
                             BountifulConfig.SERVER.villageGenRate.get()
                         )
                     }

--- a/src/main/kotlin/ejektaflex/bountiful/worldgen/JigsawHelper.kt
+++ b/src/main/kotlin/ejektaflex/bountiful/worldgen/JigsawHelper.kt
@@ -6,16 +6,23 @@ import net.minecraft.util.registry.Registry
 import net.minecraft.world.gen.feature.jigsaw.JigsawPattern
 import net.minecraft.world.gen.feature.jigsaw.JigsawPattern.PlacementBehaviour
 import net.minecraft.world.gen.feature.jigsaw.JigsawPiece
+import net.minecraft.world.gen.feature.template.ProcessorLists
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper
 
 
 object JigsawHelper {
 
-    fun registerJigsaw(server: MinecraftServer, nbtLocation: ResourceLocation, poolLocation: ResourceLocation, weight: Int = 10_000) {
+    fun registerJigsaw(server: MinecraftServer, nbtLocation: ResourceLocation, poolLocation: ResourceLocation, processorLocation: ResourceLocation, weight: Int = 10_000) {
 
         val pool = server.func_244267_aX()
             .getRegistry(Registry.JIGSAW_POOL_KEY).entries
             .find { it.key.location.toString() == poolLocation.toString() }?.value
+
+
+        var processorLists = server.func_244267_aX()
+                .getRegistry(Registry.STRUCTURE_PROCESSOR_LIST_KEY)
+                .getOptional(processorLocation)
+                .orElse(ProcessorLists.field_244101_a) // minecraft:empty
 
         val pieceList = ObfuscationReflectionHelper
             .getPrivateValue<ArrayList<JigsawPiece>, JigsawPattern>(
@@ -24,7 +31,7 @@ object JigsawHelper {
                 "field_214953_e"
             ) as MutableList<JigsawPiece>
 
-        val piece = JigsawPiece.func_242849_a(nbtLocation.toString()).apply(PlacementBehaviour.RIGID)
+        val piece = JigsawPiece.func_242851_a(nbtLocation.toString(), processorLists).apply(PlacementBehaviour.RIGID)
 
         repeat(weight) {
             pieceList.add(piece)

--- a/src/main/resources/data/bountiful/worldgen/processor_list/badlands.json
+++ b/src/main/resources/data/bountiful/worldgen/processor_list/badlands.json
@@ -1,0 +1,177 @@
+{
+  "processors": [
+    {
+      "rules": [
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_planks"
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:block_match",
+            "block": "minecraft:oak_planks"
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:orange_terracotta"
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:block_match",
+            "block": "minecraft:grass_path"
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_slab",
+            "Properties": { "type": "bottom", "waterlogged": "false" }
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+               "Name": "minecraft:oak_slab",
+               "Properties": { "type": "bottom", "waterlogged": "false" }
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_fence_gate",
+            "Properties": { "facing": "east", "in_wall": "false", "open": "false", "powered": "false"}
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+              "Name": "minecraft:spruce_fence_gate",
+              "Properties": { "facing": "east", "in_wall": "false", "open": "false", "powered": "false"}
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_fence",
+            "Properties": { "east": "false", "west": "false", "south": "false", "north": "false", "waterlogged": "false" }
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+              "Name": "minecraft:spruce_fence",
+              "Properties": { "east": "false", "west": "false", "south": "false", "north": "false", "waterlogged": "false" }
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_fence",
+            "Properties": { "east": "true", "west": "true", "south": "false", "north": "false", "waterlogged": "false" }
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+              "Name": "minecraft:spruce_fence",
+              "Properties": { "east": "true", "west": "true", "south": "false", "north": "false", "waterlogged": "false" }
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_fence",
+            "Properties": { "east": "false", "west": "false", "south": "true", "north": "true", "waterlogged": "false" }
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+              "Name": "minecraft:spruce_fence",
+              "Properties": { "east": "false", "west": "false", "south": "true", "north": "true", "waterlogged": "false" }
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_fence",
+            "Properties": { "east": "true", "west": "false", "south": "false", "north": "false", "waterlogged": "false" }
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+              "Name": "minecraft:spruce_fence",
+              "Properties": { "east": "true", "west": "false", "south": "false", "north": "false", "waterlogged": "false" }
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_fence",
+            "Properties": { "east": "false", "west": "true", "south": "false", "north": "false", "waterlogged": "false" }
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+              "Name": "minecraft:spruce_fence",
+              "Properties": { "east": "false", "west": "true", "south": "false", "north": "false", "waterlogged": "false" }
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_fence",
+            "Properties": { "east": "false", "west": "false", "south": "true", "north": "false", "waterlogged": "false" }
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+              "Name": "minecraft:spruce_fence",
+              "Properties": { "east": "false", "west": "false", "south": "true", "north": "false", "waterlogged": "false" }
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        },
+        {
+          "output_state": {
+            "Name": "minecraft:dark_oak_fence",
+            "Properties": { "east": "false", "west": "false", "south": "false", "north": "true", "waterlogged": "false" }
+          },
+          "input_predicate": {
+            "predicate_type": "minecraft:blockstate_match",
+            "block_state": {
+              "Name": "minecraft:spruce_fence",
+              "Properties": { "east": "false", "west": "false", "south": "false", "north": "true", "waterlogged": "false" }
+            }
+          },
+          "location_predicate": {
+            "predicate_type": "minecraft:always_true"
+          }
+        }
+      ],
+      "processor_type": "minecraft:rule"
+    }
+  ]
+}


### PR DESCRIPTION
I never touched kotlin before but hopefully I did alright lol.

The idea here is that in SetupLifecycle, you pass in one more resourcelocation for what processor to use based on village type. In JigsawHelper, it grabs the processor from the registry (and defaults to minecraft:empty by default if there is no processor which is what you were using before)

All that is now needed is to just make processor files in data/bountiful/worldgen/processor_list folder and name the files on the type of village. That's it! I included a badlands processor which will replace the bounty board structure piece's blocks with dark oak instead. Check it out for how it works.

Just fyi, you must list every block property in output_state and block_state. If you dont, the processor dies. More info can be found here: https://minecraft.gamepedia.com/Custom_world_generation#Processor_lists

I hope this helps! This will let you customize the bounty boards for vanilla villages as well! And players can use datapacks to override the processors too if they prefer a different block for some villages