### PR TITLE
Add two new settings to 1.20.1

### DIFF
--- a/common/src/main/java/io/ejekta/bountiful/config/BountifulConfigData.kt
+++ b/common/src/main/java/io/ejekta/bountiful/config/BountifulConfigData.kt
@@ -13,6 +13,7 @@ class BountifulConfigData {
     var boardUpdateFrequency: Int = 45
     var boardGenFrequency: Int = 2
     var flatBonusTimePerBounty: Int = 0
+    var shouldReputationDecreaseOnFail = false
     var shouldBountiesHaveTimersAndExpire = true
     var dataPackExclusions = listOf(
         "bounty_pools/bountiful/example_pool",
@@ -22,6 +23,7 @@ class BountifulConfigData {
     var objectiveModifier = 0
     var maxNumRewards = 2
     var showCompletionToast = true
+    var allowMultipleCopies = true
 
     fun buildScreen(): Screen {
         val builder = ConfigBuilder.create()
@@ -93,6 +95,17 @@ class BountifulConfigData {
             }.build()
         )
 
+        board.addEntry(
+            creator.startBooleanToggle(
+                Text.literal("Reputation Decrease on Fail"),
+                shouldReputationDecreaseOnFail
+            ).setDefaultValue(false).setTooltip(
+                Text.literal("Whether reputation should decrease when a bounty is taken but not completed")
+            ).setSaveConsumer {
+                shouldReputationDecreaseOnFail = it
+            }.build()
+        )
+
         val bounty = builder.getOrCreateCategory(Text.literal("General - Bounty"))
 
         bounty.addEntry(
@@ -131,6 +144,17 @@ class BountifulConfigData {
                 maxNumRewards = it
             }.setTextGetter {
                 textLiteral("$it Rewards")
+            }.build()
+        )
+
+        bounty.addEntry(
+            creator.startBooleanToggle(
+                Text.literal("Allow Multiple Copies"),
+                allowMultipleCopies
+            ).setDefaultValue(true).setTooltip(
+                Text.literal("Whether multiple copies of the same bounty can be taken by different players")
+            ).setSaveConsumer {
+                allowMultipleCopies = it
             }.build()
         )
 

--- a/common/src/main/java/io/ejekta/bountiful/content/gui/BoardBountySlot.kt
+++ b/common/src/main/java/io/ejekta/bountiful/content/gui/BoardBountySlot.kt
@@ -1,5 +1,6 @@
 package io.ejekta.bountiful.content.gui
 
+import io.ejekta.bountiful.config.BountifulIO
 import io.ejekta.bountiful.content.board.BoardBlockEntity
 import io.ejekta.bountiful.content.board.BoardInventory
 import io.ejekta.bountiful.util.readOnlyCopy
@@ -26,9 +27,17 @@ class BoardBountySlot(val inv: BoardInventory, index: Int, x: Int, y: Int) : Slo
                     }
                 }.filterNotNull()
             for (newIndex in matchingMaskIndices) {
-                board.maskFor(player).add(newIndex)
+                if (BountifulIO.configData.shouldReputationDecreaseOnFail) {
+                    board.finishMap[player.uuidAsString] = board.finishMap.getOrDefault(player.uuidAsString, 0) - 1
+                }
+                if (BountifulIO.configData.allowMultipleCopies) {
+                    board.maskFor(player).add(newIndex)
+                } else {
+                    board.bounties.removeStack(newIndex)
+                }
             }
         }
+
         super.onTakeItem(player, stack)
         return true
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
             }
 
             val Ejekta = object {
-                val Kambrik = "6.1.0"
+                val Kambrik = "6.1.1"
                 val KambrikSnapshot = true
             }
 


### PR DESCRIPTION
Adds two new settings:

- Reputation decrease on fail
  - Technically decreases when the bounty is taken, but adds 2 when completed to balance out. Figured this was a better solution than storing the original block in bounties and checking when they expire, as this would also cause random chunk loads.
- Allow multiple copies
  - Allows for disabling the behavior where multiple people can take the same bounty.

Defaults for these settings retain existing behaviour