### PR TITLE
Fix NPE in checkUserPlacedAllDecrees when DECREE_DATA component is null

### DIFF
--- a/common/src/main/java/io/ejekta/bountiful/content/board/BoardBlockEntity.kt
+++ b/common/src/main/java/io/ejekta/bountiful/content/board/BoardBlockEntity.kt
@@ -273,7 +273,12 @@ class BoardBlockEntity(pos: BlockPos, state: BlockState) : BlockEntity(Bountiful
         if (newStack.count == 0) {
             return
         }
-        val newDecrees = newStack[BountifulContent.DECREE_DATA]!!.ids
+        // Data component can be absent on decree stacks created/duplicated out-of-band
+        // (e.g. via creative pick-block on a board slot, modded item interactions, or
+        // an NBT-cleared stack from another mod). Bail out cleanly rather than NPEing
+        // the server thread — see issue #336.
+        val decreeData = newStack[BountifulContent.DECREE_DATA] ?: return
+        val newDecrees = decreeData.ids
         val decs = getBoardDecrees().map { it.id }.toSet() + newDecrees
         val allDecreesSet = BountifulContent.Decrees.map { it.id }.toSet()
         val allDecrees = decs.intersect(allDecreesSet) == allDecreesSet


### PR DESCRIPTION
## Summary

Fixes the server-freeze crash described in #336.

`BoardBlockEntity.checkUserPlacedAllDecrees` used a non-null assertion (`!!`) on the `DECREE_DATA` data component. When the component was absent — for example on a decree stack duplicated out-of-band (creative pick-block on a board slot, modded item manipulation, or an NBT-cleared stack from another mod) — the `!!` threw an NPE on the server thread, which the ServerHangWatchdog then escalated into a full server freeze several minutes later.

## Fix

Replace the `!!` with an early return, matching the null-safe patterns already used elsewhere in this file:

- Line 140: `it[BountifulContent.DECREE_DATA]?.ids ?: emptySet()`
- Line 295: `val info = stack[BountifulContent.BOUNTY_INFO] ?: continue`

The `count == 0` early return above already covers the consumed-stack case, so the new `?: return` only triggers on the truly null-component case the `!!` was crashing on.

## Reproduction

Per the issue:

```
Caused by: java.lang.NullPointerException
  at io.ejekta.bountiful.content.board.BoardBlockEntity.checkUserPlacedAllDecrees(BoardBlockEntity.kt:271)
  at io.ejekta.bountiful.content.board.BoardBlockEntity.onUserPlacedDecree(BoardBlockEntity.kt:264)
  at io.ejekta.bountiful.content.gui.BoardDecreeSlot.safeInsert(BoardDecreeSlot.kt:20)
```

The crash report points to line 271, which was the `!!` expression in the original source (and is the `decreeData = …` line in this PR's diff). Lines and surrounding context match the reported stack trace.

## Risk

Trivial. One-line behavioural change (skip the function instead of crashing) on a code path that previously took the server down. No public API changes, no new imports.